### PR TITLE
fix(ingestion): reduce NCBI esearch rate-limit connection resets

### DIFF
--- a/src/biometaharmonizer/ingestion.py
+++ b/src/biometaharmonizer/ingestion.py
@@ -25,6 +25,7 @@ Working directory note (Colab):
 import importlib.resources
 import json
 import logging
+import random
 import re
 import time
 import xml.etree.ElementTree as ET
@@ -49,7 +50,7 @@ ASSEMBLY_SUMMARY_REFSEQ = "https://ftp.ncbi.nlm.nih.gov/genomes/ASSEMBLY_REPORTS
 ASSEMBLY_SUMMARY_GENBANK = "https://ftp.ncbi.nlm.nih.gov/genomes/ASSEMBLY_REPORTS/assembly_summary_genbank.txt"
 
 _BATCH_SIZE = 200
-_ESEARCH_BATCH = 100
+_ESEARCH_BATCH = 50
 _MAX_RETRIES = 3
 _RETRY_BASE_S = 2
 _RETRY_MAX_S = 30
@@ -209,6 +210,12 @@ def ingest(source, api_key: str = None, cache_dir=None) -> pd.DataFrame:
 
     Entrez.email = ENTREZ_EMAIL
     Entrez.api_key = ENTREZ_API_KEY
+
+    if ENTREZ_API_KEY is None:
+        logger.warning(
+            "No NCBI API key set. Rate limit is 3 req/s; connection resets may occur. "
+            "Register a free key at https://www.ncbi.nlm.nih.gov/account/ and call set_api_key()."
+        )
 
     ids = _load_ids(source)
     ids = _deduplicate(ids)
@@ -439,6 +446,9 @@ def _resolve_accessions_to_uids(accessions: list) -> dict:
     acc_to_uid = {}
 
     for start in range(0, len(accessions), _ESEARCH_BATCH):
+        if start == 0:
+            time.sleep(inter_req_sleep)
+
         batch = accessions[start:start + _ESEARCH_BATCH]
         term = " OR ".join(f"{acc}[Accession]" for acc in batch)
 
@@ -456,7 +466,8 @@ def _resolve_accessions_to_uids(accessions: list) -> dict:
             except Exception as exc:
                 wait = min(_RETRY_BASE_S ** attempt, _RETRY_MAX_S)
                 logger.warning(
-                    "esearch attempt %d/%d failed: %s. Retrying in %ds...",
+                    "esearch attempt %d/%d: NCBI closed connection (likely rate limit): %s. "
+                    "Retrying in %ds...",
                     attempt, _MAX_RETRIES, exc, wait,
                 )
                 time.sleep(wait)
@@ -495,7 +506,7 @@ def _resolve_accessions_to_uids(accessions: list) -> dict:
                 if acc and uid:
                     acc_to_uid[acc] = uid
 
-        time.sleep(inter_req_sleep)
+        time.sleep(inter_req_sleep + random.uniform(0, 0.05))
 
     return acc_to_uid
 
@@ -549,7 +560,7 @@ def _fetch_biosample_metadata(samn_ids: list, synonym_lookup: dict = None) -> pd
         fetched = min(start + _BATCH_SIZE, total)
         logger.info("Fetched %d / %d (%d/%d batches)", fetched, total, batch_i + 1, n_batches)
         if batch_i < n_batches - 1:
-            time.sleep(inter_batch_sleep)
+            time.sleep(inter_batch_sleep + random.uniform(0, 0.05))
 
     if failed_ids:
         logger.warning("%d UIDs could not be fetched: %s", len(failed_ids), failed_ids[:10])


### PR DESCRIPTION
Addresses #8.

## What and why

Without an NCBI API key the rate limit is 3 req/s. The previous fixed inter-request sleep of 0.34 s allowed roughly 2.9 req/s, leaving no margin for DNS, TLS, or any scheduling jitter. The first batch also fired with no warm-up, so NCBI's edge would see a cold burst and reset the TCP connection before returning an HTTP response. Larger OR-joined search terms (100 accessions per batch) compounded this by giving the NCBI load balancer more surface to reject before parsing.

I might be wrong about the exact threshold, but the combination of all three factors makes the connection resets reliably reproducible without a key, and the fixes below should meaningfully reduce their frequency.

## Changes

- `_ESEARCH_BATCH`: 100 → 50. Shorter OR-term strings are less likely to be dropped at the connection layer.
- Pre-first-batch warm-up sleep in `_resolve_accessions_to_uids`. Prevents an immediate cold burst at ingestion start.
- Random jitter (0–50 ms) added to all inter-request sleeps. Keeps successive batches from landing in a tight burst that triggers the rate limit.
- Retry log message updated to say "NCBI closed connection (likely rate limit)" instead of just surfacing the raw exception, so users understand what they're seeing.
- One-time warning in `ingest()` when no API key is configured, pointing users to registration.

## Notes

The jitter range (0–50 ms) is conservative. With the base sleep staying at 0.34 s for unauthenticated users, effective average throughput stays well below 3 req/s. If this direction doesn't fit the project style, happy to adjust.

---

*This PR was prepared with AI assistance. All changes were reviewed for correctness before submission.*