### PR TITLE
ci: add GitHub Pages docs deployment workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,49 @@
+name: Build and deploy docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "src/**"
+      - "pyproject.toml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install package and docs dependencies
+        run: pip install -e ".[docs]"
+
+      - name: Build Sphinx docs
+        run: sphinx-build -b html docs docs/_build -W --keep-going
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/_build
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/deploy-pages@v4
+        id: deployment


### PR DESCRIPTION
## What this does

Adds a GitHub Actions workflow that automatically builds and deploys the Sphinx documentation to GitHub Pages on every push to `main` that touches `docs/`, `src/`, or `pyproject.toml`.

## After merging

1. Go to **Settings → Pages** and set Source to **GitHub Actions**
2. The workflow will trigger on merge and deploy to `https://rustam-bioinfo.github.io/BioMetaHarmonizer/`

## Files changed

- `.github/workflows/docs.yml` — new workflow file